### PR TITLE
feat: single push for auto* commands + `setver prep` prepared releases

### DIFF
--- a/.github/workflows/bash_ci.yml
+++ b/.github/workflows/bash_ci.yml
@@ -41,10 +41,10 @@ jobs:
     - name: Run BATS tests
       run: |
         echo "🧪 Running setver test suite..."
-        bats tests/setver.bats
+        bats tests/setver.bats tests/prep.bats
 
     - name: Test summary
       if: success()
       run: |
         echo "✅ All tests passed!"
-        echo "Total tests: $(bats tests/setver.bats 2>&1 | grep -c '^ok')"
+        echo "Total tests: $(bats tests/setver.bats tests/prep.bats 2>&1 | grep -c '^ok')"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,13 +61,13 @@ jobs:
     - name: Run BATS test suite
       run: |
         echo "🧪 Running setver test suite on ${{ matrix.os }}..."
-        bats tests/setver.bats --tap
+        bats tests/setver.bats tests/prep.bats --tap
 
     - name: Generate test report
       if: always()
       run: |
         echo "## Test Results for ${{ matrix.os }}" >> $GITHUB_STEP_SUMMARY
-        if bats tests/setver.bats 2>&1 | tee test-output.txt; then
+        if bats tests/setver.bats tests/prep.bats 2>&1 | tee test-output.txt; then
           TOTAL=$(grep -c '^ok' test-output.txt || echo 0)
           echo "✅ **All $TOTAL tests passed!**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -126,7 +126,7 @@ jobs:
         echo "" >> coverage.md
 
         # Run tests and capture output
-        if bats tests/setver.bats 2>&1 | tee full-test-output.txt; then
+        if bats tests/setver.bats tests/prep.bats 2>&1 | tee full-test-output.txt; then
           TOTAL=$(grep -c '^ok' full-test-output.txt)
           echo "✅ **$TOTAL / $TOTAL tests passing (100%)**" >> coverage.md
           echo "" >> coverage.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- add `setver prep` prepared-release command family (`major`/`minor`/`finish`/`pause`/`resume`/`status`/`abort`): while a prep is active, all git tags are hard-suppressed (marker file `.setver-prep`), and the single real release tag is created only at `prep finish` — so an in-progress major release never pushes half-finished tags to Packagist/etc.
 - `autopatch`/`ap`, `autominor` and `automajor` now commit, tag and push in a single `git push` at the end, so they trigger only 1 CI run instead of one per intermediate push
 - add `automajor` command
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,15 @@ The script can read and update versions from:
 - `./setver push` - Commit and push changes
 - `./setver skip` - Commit with [skip ci] flag
 
+### Prepared Releases (`setver prep`)
+For preparing a big major/minor release as a single publish event. While a prep is active (marker file `.setver-prep` present at repo root), **all git tags are hard-suppressed** so half-finished versions never become installable via Packagist/etc.
+- `./setver prep major` / `./setver prep minor` - Start a prepared release on a `prep-v<target>` branch; sets version files to the clean target, commits the marker, suppresses tags
+- `./setver prep finish` - Release the single real tag (clean target by default; `--keep-version` keeps the drifted number, `--no-ff` merges the prep branch locally first). Runs on the base branch after the prep is merged; pushes commits + tag in one push
+- `./setver prep pause [--stash]` / `./setver prep resume` - Step off / back onto the prep branch, remembering where you were (local session file `.git/setver-prep-session`)
+- `./setver prep status` - Show target, suppression state, and how far the base branch has moved
+- `./setver prep abort` - Cancel the prep and delete its branch
+- Tag suppression is enforced at a single choke point (`prep_block_tag` in `commit_and_tag_version`, plus guards in `push_if_possible`/`push_all_once`), so no command path (`new`/`set`/`ap`/`autominor`/`automajor`) can bypass it.
+
 ### Utilities
 - `./setver md` - Create VERSION.md file if it doesn't exist
 - `./setver message` - Show the auto-generated message for current changes

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,8 @@ Flags, options and parameters:
     -l|--log_dir <?> : [option] folder for log files   [default: /Users/pforret/log/setver]
     -t|--tmp_dir <?> : [option] folder for temp files  [default: /tmp/setver]
     -p|--prefix <?>  : [option] prefix to use for git tags  [default: v]
-    <action>         : [parameter] action to perform: get/check/push/set/new/md/message/auto/autopatch/ap/skip/changelog/history
-    <input>          : [parameter] input text (optional)
+    <action>         : [parameter] action to perform: get/check/push/set/new/md/message/auto/autopatch/ap/autominor/automajor/prep/skip/changelog/history
+    <input>          : [parameter] input text, or prep sub-action (optional)
                                                                                                              
                                   
 ### TIPS & EXAMPLES
@@ -61,6 +61,9 @@ Flags, options and parameters:
 * use 'setver autopatch' or 'setver ap' to do commit/push with auto-generated commit message & bump patch version
 * use 'setver autominor' to do commit/push with auto-generated commit message & bump minor version
 * use 'setver automajor' to do commit/push with auto-generated commit message & bump major version
+* use 'setver prep major' or 'setver prep minor' to start a prepared release (git tags stay suppressed until you finish)
+* use 'setver prep finish' to create the single release tag once the prepared work is merged onto the base branch
+* use 'setver prep status/pause/resume/abort' to inspect or manage a prepared release
 * use 'setver skip' to do commit/push with auto-generated commit message and skip GH actions
 * use 'setver md' to generate a correct VERSION.md file, if it does not yet exist
 * use 'setver set x.y.z' to set new version number
@@ -85,6 +88,37 @@ Flags, options and parameters:
 Use `-f|--force` to skip the confirmation prompts.
 
 The combined commands `setver ap`/`autopatch`, `setver autominor` and `setver automajor` commit the code changes, bump the version and create the git tag, then do a **single** `git push` of commits and tags together at the very end — so they trigger only 1 CI/CD run instead of one per intermediate push.
+
+## Prepared releases (`setver prep`)
+
+Composer/Packagist (and most other consumers) resolve installable versions from **git tags**. When you prepare a big `v2.0.0`, bumping versions while you work would push intermediate tags (`v2.0.1`, `v2.0.2`, …) that become installable immediately — because tags are repository-global, not branch-scoped. A major release should instead be **one publish event**, on the base branch, after the work is merged.
+
+`setver prep` enforces that: while a prep is active, **all git tags are hard-suppressed**. The single real tag is created only at `prep finish`.
+
+```sh
+# on main, start preparing the next major (2.0.0) on a dedicated branch
+setver prep major            # -> creates branch 'prep-v2', writes .setver-prep, sets files to 2.0.0
+
+# develop as usual; dev version numbers may climb, but NO tag is ever pushed
+setver ap                    # 2.0.0 -> 2.0.1 (files + commit), tag suppressed
+setver ap                    # 2.0.1 -> 2.0.2, tag suppressed
+
+# step away and come back at any time
+setver prep pause --stash    # remember the branch, stash WIP, return to base
+setver prep resume           # jump back onto the prep branch, restore the WIP
+setver prep status           # target, suppression, and how far base has moved
+
+# after the prep branch is merged into the base branch (e.g. the PR is merged):
+setver prep finish           # releases the clean target v2.0.0 as the ONE tag, in a single push
+```
+
+* The marker file **`.setver-prep`** is committed to the prep branch, so it travels with the PR and into the base branch on merge. Its presence is the tag-suppression switch — the base branch therefore stays suppressed in the window between merge and `finish`, preventing an accidental tag.
+* `prep finish` releases the **clean target** (`2.0.0`) by default, not the drifted dev number; pass `--keep-version` to tag whatever the files currently say. Use `--no-ff` to have `finish` merge the prep branch locally first (for a non-PR workflow).
+* `prep finish` refuses unless the prep branch is actually merged into the base branch (override with `-f`).
+* **Hotfixes are unaffected.** A `v1.x` hotfix branched off the release tag (`git checkout -b hotfix-1.4.4 v1.4.3`) carries no `.setver-prep`, so `setver ap` there tags `v1.4.4` normally while the prep stays suppressed elsewhere. `prep status` shows how many commits landed on the base branch since the prep started — your cue to merge the fix into the prep branch so it isn't lost at `2.0.0`.
+* `prep abort` cancels a prep: it returns to the base branch and deletes the prep branch (locally, and optionally on the remote).
+
+`prep patch` is intentionally not supported — a patch doesn't warrant a prepared branch; use `setver ap`.
 
 ## Conventional Commits messages
 

--- a/setver.sh
+++ b/setver.sh
@@ -19,8 +19,9 @@ flag|O|CONVENTIONAL|build a Conventional Commits message interactively
 option|l|log_dir|folder for log files |$HOME/log/$script_prefix
 option|t|tmp_dir|folder for temp files|/tmp/$script_prefix
 option|p|prefix|prefix to use for git tags|v
-param|1|action|action to perform: get/check/push/set/new/md/message/auto/autopatch/ap/autominor/automajor/skip/changelog/history
-param|?|input|input text
+param|1|action|action to perform: get/check/push/set/new/md/message/auto/autopatch/ap/autominor/automajor/prep/skip/changelog/history
+param|?|input|input text (or prep sub-action: major/minor/finish/pause/resume/status/abort)
+param|?|input2|optional modifier for 'prep' (e.g. --keep-version, --no-ff, --stash)
 " | grep -v '^#' | grep -v '^\s*$'
 }
 
@@ -99,6 +100,14 @@ function main() {
     set_versions major
     SETVER_DEFER_PUSH=0
     push_all_once
+    ;;
+
+  #TIP: use «$script_prefix prep major» or «$script_prefix prep minor» to start a prepared release (git tags stay suppressed until you finish)
+  #TIP: use «$script_prefix prep finish» to create the single release tag once the prepared work is merged onto the base branch
+  #TIP: use «$script_prefix prep status/pause/resume/abort» to inspect or manage a prepared release
+  prep)
+    # shellcheck disable=SC2154
+    do_prep "$input" "$input2"
     ;;
 
   #TIP: use «$script_prefix skip» to do commit/push with auto-generated commit message and skip GH actions
@@ -377,6 +386,10 @@ function check_versions() {
   local version_sh
   success "$script_prefix check versions:"
 
+  if prep_is_active; then
+    alert "prep mode active → $(prep_target), tags suppressed (finish with '$script_prefix prep finish')"
+  fi
+
   version_tag=$(get_version_tag)
   [[ -n $version_tag ]] && show_version "$version_tag" "git tag"
   version_composer=$(get_version_composer)
@@ -524,6 +537,12 @@ function commit_and_tag_version() {
     alert "'git commit' failed - check $outfile for details"
   # push all files changes
   push_if_possible "N"
+
+  # SINGLE TAG CHOKE POINT: while a prep is active, never create or push a tag.
+  # The version files/commit above still happen; only tagging is suppressed.
+  if prep_block_tag; then
+    return 0
+  fi
 
   outfile="$tmp_dir/set_version.tag.log"
   # shellcheck disable=SC2154
@@ -814,6 +833,7 @@ function commit_and_push() {
   untracked_files=$(git ls-files --others --exclude-standard)
   if [[ -n "$untracked_files" ]]; then
     alert "Untracked files detected:"
+    # shellcheck disable=SC2001 # per-line indent is clearest with sed here
     echo "$untracked_files" | sed 's/^/  /'
     if confirm "Shall I 'git add' these files before committing?"; then
       # shellcheck disable=SC2086
@@ -885,6 +905,14 @@ function push_all_once() {
     return 0
   fi
   current_branch=$(git rev-parse --abbrev-ref HEAD)
+  # Route the combined --tags push through the prep guard too: while a prep is
+  # active, push commits only so no tag ever reaches the remote.
+  if prep_is_active; then
+    success "prep mode active → push commits only (tags suppressed) to [$check_remote]"
+    git push -u origin "$current_branch" &>"$outfile" ||
+      die "'git push -u origin $current_branch' failed - check $outfile for details"
+    return 0
+  fi
   success "push commits and tags to [$check_remote] in a single push"
   git push -u origin "$current_branch" --tags &>"$outfile" ||
     die "'git push -u origin $current_branch --tags' failed - check $outfile for details"
@@ -901,6 +929,12 @@ function push_if_possible() {
   local flags=${1:-}
   local current_branch=""
   local has_upstream=""
+  # Defence in depth: a tag push ("Y") is hard-disabled while a prep is active,
+  # so no code path can bypass the suppression invariant.
+  if [[ "$flags" == "Y" ]] && prep_is_active; then
+    debug "prep mode active → skip tag push"
+    return 0
+  fi
   outfile="$tmp_dir/${script_prefix}_push.log"
   check_remote=$(git remote -v | awk '/\(push\)/ {print $2}')
   if [[ -n "$check_remote" ]]; then
@@ -924,6 +958,416 @@ function push_if_possible() {
     debug "No remote set - skip git push"
   fi
 }
+
+#####################################################################
+## Prepared releases ('setver prep ...')
+#####################################################################
+# A "prep" is a prepared major/minor release. While the committed marker file
+# '.setver-prep' is present at the repo root, setver NEVER creates or pushes a
+# git tag (see prep_block_tag / push_if_possible / push_all_once). The single
+# real tag is created only by 'prep finish', after the marker has been removed.
+
+PREP_MARKER=".setver-prep"
+
+function prep_marker_path() {
+  # committed, shared marker at the repo root - its presence suppresses tags
+  echo "${git_repo_root:-.}/$PREP_MARKER"
+}
+
+function prep_session_path() {
+  # local, personal "where was I" pointer - lives inside .git, never tracked
+  local gitdir
+  gitdir=$(git rev-parse --git-dir 2>/dev/null || echo ".git")
+  echo "$gitdir/setver-prep-session"
+}
+
+function prep_is_active() {
+  # the core invariant switch: true when a prep marker exists at the repo root
+  [[ -f "$(prep_marker_path)" ]]
+}
+
+function prep_read() {
+  # echo the value of a KEY from the marker file (empty if absent)
+  local key="$1"
+  prep_is_active || { echo ""; return 0; }
+  grep -E "^$key=" "$(prep_marker_path)" 2>/dev/null | head -1 | cut -d= -f2-
+}
+
+function prep_target() {
+  prep_read SETVER_PREP_TARGET
+}
+
+function prep_block_tag() {
+  # Called at the single tag choke point. Returns 0 (=block) when a prep is
+  # active, after printing the suppression notice; returns 1 otherwise.
+  if prep_is_active; then
+    alert "prep mode active → preparing $(prep_target), tag NOT created/pushed (use '$script_prefix prep finish' to release)"
+    return 0
+  fi
+  return 1
+}
+
+function prep_compute_target() {
+  # $1 = current semver, $2 = level (major|minor)  → echoes "<target> <branch>"
+  local current="$1" level="$2" M m
+  M=$(echo "$current" | cut -d. -f1)
+  m=$(echo "$current" | cut -d. -f2)
+  case "$level" in
+  major) echo "$((M + 1)).0.0 prep-v$((M + 1))" ;;
+  minor) echo "$M.$((m + 1)).0 prep-v$M.$((m + 1))" ;;
+  *) die "prep level must be 'major' or 'minor'" ;;
+  esac
+}
+
+function prep_branch_name() {
+  # $1 = target version, $2 = level  → echoes the prep branch name
+  local target="$1" level="$2" M m
+  M=$(echo "$target" | cut -d. -f1)
+  m=$(echo "$target" | cut -d. -f2)
+  case "$level" in
+  minor) echo "prep-v$M.$m" ;;
+  *) echo "prep-v$M" ;;
+  esac
+}
+
+function prep_find_branches() {
+  # echo local branches whose tree carries a committed .setver-prep marker
+  local b
+  git for-each-ref --format='%(refname:short)' refs/heads/ | while read -r b; do
+    git cat-file -e "$b:$PREP_MARKER" 2>/dev/null && echo "$b"
+  done
+}
+
+function do_prep() {
+  # dispatch 'setver prep <sub> [modifier]'
+  local sub="${1:-}" opt="${2:-}"
+  case "${sub,,}" in
+  major | minor) prep_start "${sub,,}" ;;
+  finish) prep_finish "$opt" ;;
+  pause) prep_pause "$opt" ;;
+  resume) prep_resume ;;
+  status) prep_status ;;
+  abort) prep_abort ;;
+  patch) die "'prep patch' is not supported — a patch doesn't need a prepared branch; use '$script_prefix ap' instead" ;;
+  "") die "prep needs a sub-action: major/minor/finish/pause/resume/status/abort" ;;
+  *) die "unknown prep sub-action [$sub] — use major/minor/finish/pause/resume/status/abort" ;;
+  esac
+}
+
+function prep_start() {
+  # 'setver prep major|minor' — begin a prepared release on a fresh prep branch
+  local level="$1"
+  local current target branch base base_commit created
+
+  prep_is_active &&
+    die "a prep is already active — see '$script_prefix prep status' (or '$script_prefix prep abort' to cancel it)"
+
+  if [[ -n "$(git status -s)" ]] && ! flag_set "$force"; then
+    die "commit or stash your changes before starting a prep"
+  fi
+
+  current=$(get_any_version)
+  # NOTE: this script sets IFS=$'\n\t' (strict mode), so read won't split on
+  # spaces by default — force a space IFS just for this split.
+  IFS=' ' read -r target branch < <(prep_compute_target "$current" "$level")
+
+  base=$(git rev-parse --abbrev-ref HEAD)
+  base_commit=$(git rev-parse --short HEAD)
+  created=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    if flag_set "$force"; then
+      git checkout "$branch" >/dev/null 2>&1 || die "could not switch to existing branch [$branch]"
+    else
+      die "branch [$branch] already exists — use -f to reuse it, or '$script_prefix prep abort' first"
+    fi
+  else
+    git checkout -b "$branch" >/dev/null 2>&1 || die "could not create branch [$branch]"
+  fi
+
+  {
+    echo "SETVER_PREP_TARGET=$target"
+    echo "SETVER_PREP_LEVEL=$level"
+    echo "SETVER_PREP_BASE=$base"
+    echo "SETVER_PREP_BASE_COMMIT=$base_commit"
+    echo "SETVER_PREP_CREATED=$created"
+  } >"$(prep_marker_path)"
+  git add "$(prep_marker_path)"
+
+  # set the version files to the clean target - the tag path stays blocked
+  update_version_files "$target"
+
+  git commit -m "chore(prep): start preparing v$target (tags suppressed)" >/dev/null 2>&1 ||
+    alert "'git commit' failed while starting prep - check 'git status'"
+
+  success "prep started → preparing v$target ($level)"
+  out "  branch : $branch  (from $base @ $base_commit)"
+  out "  tags   : suppressed until '$script_prefix prep finish'"
+  out "  next   : develop as usual; '$script_prefix ap' bumps dev versions without tagging, then merge & '$script_prefix prep finish'"
+
+  flag_set "$force" && prep_push_branch "$branch"
+}
+
+function prep_push_branch() {
+  local branch="$1"
+  git remote get-url origin >/dev/null 2>&1 || return 0
+  if git push -u origin "$branch" >/dev/null 2>&1; then
+    success "pushed prep branch [$branch]"
+  else
+    alert "could not push prep branch [$branch]"
+  fi
+}
+
+function prep_finish() {
+  # 'setver prep finish' — turn the prepared work into the single real release
+  local opt="${1:-}"
+  local keep_version=0 no_ff=0
+  case "$opt" in
+  --keep-version | --keep_version) keep_version=1 ;;
+  --no-ff | --no_ff) no_ff=1 ;;
+  "") : ;;
+  *) die "unknown option for 'prep finish' [$opt] — use --keep-version or --no-ff" ;;
+  esac
+
+  prep_is_active || die "not in prep mode — nothing to finish"
+
+  local target level base prep_branch current_branch
+  target=$(prep_read SETVER_PREP_TARGET)
+  level=$(prep_read SETVER_PREP_LEVEL)
+  base=$(prep_read SETVER_PREP_BASE)
+  prep_branch=$(prep_branch_name "$target" "$level")
+  current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+  if [[ "$current_branch" != "$base" ]]; then
+    if flag_set "$force"; then
+      alert "finishing prep from [$current_branch], expected base [$base] (forced)"
+    else
+      die "run 'prep finish' on the base branch [$base] (currently on [$current_branch]); use -f to override"
+    fi
+  fi
+
+  # the prep work must be merged: its tip must be an ancestor of HEAD
+  if git show-ref --verify --quiet "refs/heads/$prep_branch"; then
+    if ! git merge-base --is-ancestor "$prep_branch" HEAD; then
+      if ((no_ff)); then
+        announce "merging prep branch [$prep_branch] into [$current_branch]"
+        git merge --no-ff -m "chore(prep): merge $prep_branch" "$prep_branch" >/dev/null 2>&1 ||
+          die "merge of [$prep_branch] failed — resolve conflicts, then run 'prep finish' again"
+      elif flag_set "$force"; then
+        alert "prep branch [$prep_branch] not merged into [$current_branch] (forced)"
+      else
+        die "prep branch [$prep_branch] is not merged into [$current_branch] — merge the PR first (or use --no-ff to merge locally, or -f)"
+      fi
+    fi
+  else
+    debug "prep branch [$prep_branch] not found locally — assuming already merged"
+  fi
+
+  local version
+  if ((keep_version)); then
+    version=$(get_any_version)
+    success "releasing drifted version $version (--keep-version)"
+  else
+    version="$target"
+    success "releasing clean target v$version"
+  fi
+
+  update_version_files "$version"
+
+  # remove the marker (this exits prep mode) and stage its deletion
+  git rm -f --quiet "$(prep_marker_path)" >/dev/null 2>&1 || rm -f "$(prep_marker_path)"
+
+  local release_msg="chore(release): v$version"
+  if flag_set "$CONVENTIONAL"; then
+    local conv_message=""
+    conv_message="$(conventional_commit_message)"
+    [[ -n "$conv_message" ]] && release_msg="$conv_message"
+  fi
+  git commit -m "$release_msg" >/dev/null 2>&1 ||
+    alert "'git commit' failed for release - check 'git status'"
+
+  # marker is gone → the tag path is unblocked; tag + push commits & tag together
+  # shellcheck disable=SC2154
+  git tag "$prefix$version" >/dev/null 2>&1 || alert "'git tag' failed for $prefix$version"
+  success "set git version tag: $prefix$version"
+  push_all_once
+
+  local remote_url
+  remote_url=$(git config remote.origin.url 2>/dev/null || echo "")
+  [[ -n "$remote_url" ]] && show_repo_url "$remote_url"
+  success "released v$version 🎉  (the only $level tag is now $prefix$version, on $base history)"
+}
+
+function prep_pause() {
+  # 'setver prep pause' — step off the prep branch, remembering the way back
+  local opt="${1:-}"
+  local stash=0
+  case "$opt" in
+  --stash) stash=1 ;;
+  "") : ;;
+  *) die "unknown option for 'prep pause' [$opt] — use --stash" ;;
+  esac
+
+  if ! prep_is_active; then
+    alert "not on a prep branch — nothing to pause"
+    return 0
+  fi
+
+  local target base branch tip base_commit stash_ref="" return_to commits
+  target=$(prep_read SETVER_PREP_TARGET)
+  base=$(prep_read SETVER_PREP_BASE)
+  base_commit=$(prep_read SETVER_PREP_BASE_COMMIT)
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  tip=$(git rev-parse --short HEAD)
+
+  if [[ -n "$(git status -s)" ]]; then
+    if ((stash)); then
+      git stash push -u -m "setver prep pause" >/dev/null 2>&1 || die "'git stash' failed"
+      stash_ref="stash@{0}"
+    else
+      die "commit or use --stash before pausing"
+    fi
+  fi
+
+  return_to="$base"
+  if ! git show-ref --verify --quiet "refs/heads/$return_to"; then
+    return_to=$(git rev-parse --abbrev-ref '@{-1}' 2>/dev/null || echo "$base")
+  fi
+
+  commits=$(git rev-list --count "$base_commit..HEAD" 2>/dev/null || echo "?")
+
+  git checkout "$return_to" >/dev/null 2>&1 || die "could not checkout [$return_to]"
+
+  {
+    echo "SETVER_SESSION_BRANCH=$branch"
+    echo "SETVER_SESSION_PAUSED_AT=$tip"
+    [[ -n "$stash_ref" ]] && echo "SETVER_SESSION_STASH=$stash_ref"
+    echo "SETVER_SESSION_RETURNED_TO=$return_to"
+  } >"$(prep_session_path)"
+
+  success "$char_wait  paused prep of $target ($commits commits in) — now on $return_to. Resume with '$script_prefix prep resume'."
+}
+
+function prep_resume() {
+  # 'setver prep resume' — return to the paused prep branch
+  local session branch="" stash_ref=""
+  session="$(prep_session_path)"
+
+  if [[ -f "$session" ]]; then
+    branch=$(grep -E '^SETVER_SESSION_BRANCH=' "$session" | cut -d= -f2-)
+    stash_ref=$(grep -E '^SETVER_SESSION_STASH=' "$session" | cut -d= -f2- || true)
+  else
+    local candidates count
+    candidates=$(prep_find_branches)
+    count=$(printf '%s\n' "$candidates" | grep -c . || true)
+    if [[ "$count" -eq 0 ]]; then
+      die "no paused prep session, and no prep branch found to resume"
+    elif [[ "$count" -eq 1 ]] || flag_set "$force"; then
+      branch=$(printf '%s\n' "$candidates" | head -1)
+      alert "no session file — resuming detected prep branch [$branch]"
+    else
+      die "multiple prep branches found; checkout the one you want, or use -f:\n$candidates"
+    fi
+  fi
+
+  [[ -z "$branch" ]] && die "could not determine which prep branch to resume"
+  git checkout "$branch" >/dev/null 2>&1 || die "could not checkout prep branch [$branch]"
+
+  if [[ -n "$stash_ref" ]]; then
+    if git stash pop >/dev/null 2>&1; then
+      success "restored stashed changes"
+    else
+      alert "could not auto-apply stashed changes ($stash_ref) — resolve manually with 'git stash pop'"
+    fi
+  fi
+
+  rm -f "$session"
+  prep_status
+}
+
+function prep_status() {
+  # 'setver prep status' — read-only summary, safe to run anytime
+  local session
+  session="$(prep_session_path)"
+
+  if prep_is_active; then
+    local target level base base_commit branch commits_since base_ahead
+    target=$(prep_read SETVER_PREP_TARGET)
+    level=$(prep_read SETVER_PREP_LEVEL)
+    base=$(prep_read SETVER_PREP_BASE)
+    base_commit=$(prep_read SETVER_PREP_BASE_COMMIT)
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    commits_since=$(git rev-list --count "$base_commit..HEAD" 2>/dev/null || echo "?")
+    base_ahead=$(git rev-list --count "$base_commit..$base" 2>/dev/null || echo "?")
+    success "prep in progress → preparing v$target ($level)"
+    out "  branch  : $branch"
+    out "  base    : $base @ $base_commit"
+    out "  tags    : suppressed (finish with '$script_prefix prep finish')"
+    out "  commits : $commits_since since prep started"
+    out "  on $base : $base_ahead new commit(s) since prep started$([[ "$base_ahead" != "0" ]] && echo " — merge them into the prep branch before finishing")"
+  else
+    out "no prep in progress"
+  fi
+
+  if [[ -f "$session" ]]; then
+    local here paused_branch
+    here=$(git rev-parse --abbrev-ref HEAD)
+    paused_branch=$(grep -E '^SETVER_SESSION_BRANCH=' "$session" | cut -d= -f2-)
+    out "$char_wait  paused, currently on $here; resume with '$script_prefix prep resume' (prep branch: $paused_branch)"
+  fi
+}
+
+function prep_abort() {
+  # 'setver prep abort' — cancel a prep and delete its branch
+  local branch="" base="" target=""
+  if prep_is_active; then
+    target=$(prep_read SETVER_PREP_TARGET)
+    base=$(prep_read SETVER_PREP_BASE)
+    branch=$(prep_branch_name "$target" "$(prep_read SETVER_PREP_LEVEL)")
+  elif [[ -f "$(prep_session_path)" ]]; then
+    branch=$(grep -E '^SETVER_SESSION_BRANCH=' "$(prep_session_path)" | cut -d= -f2-)
+    base=$(grep -E '^SETVER_SESSION_RETURNED_TO=' "$(prep_session_path)" | cut -d= -f2-)
+  else
+    die "no prep in progress"
+  fi
+
+  confirm "Abort prep of ${target:-$branch} and delete branch [$branch]?" || {
+    out "abort cancelled"
+    return 0
+  }
+
+  local current
+  current=$(git rev-parse --abbrev-ref HEAD)
+  if [[ -n "$base" ]] && git show-ref --verify --quiet "refs/heads/$base"; then
+    git checkout "$base" >/dev/null 2>&1 || die "could not checkout base branch [$base]"
+    current="$base"
+  fi
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    if [[ "$branch" != "$current" ]] && git merge-base --is-ancestor "$branch" HEAD 2>/dev/null; then
+      alert "prep branch [$branch] appears already merged into [$current] — '$script_prefix prep finish' is the right tool there, not abort"
+    fi
+    if git branch -D "$branch" >/dev/null 2>&1; then
+      success "deleted local branch [$branch]"
+    else
+      alert "could not delete local branch [$branch]"
+    fi
+  fi
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    if confirm "Also delete the remote branch [origin/$branch]?"; then
+      if git push origin --delete "$branch" >/dev/null 2>&1; then
+        success "deleted remote branch [$branch]"
+      else
+        alert "could not delete remote branch [$branch] (maybe it was never pushed)"
+      fi
+    fi
+  fi
+
+  rm -f "$(prep_session_path)"
+  success "prep aborted"
+}
+
 #####################################################################
 ################### DO NOT MODIFY BELOW THIS LINE ###################
 #####################################################################

--- a/tests/prep.bats
+++ b/tests/prep.bats
@@ -1,0 +1,239 @@
+#!/usr/bin/env bats
+# prep.bats - tests for the 'setver prep' prepared-release command family
+#
+# The temp test repo has no remote, so push_if_possible()/push_all_once() no-op
+# and any created tag stays local - which is exactly what we assert on.
+
+load test_helper
+
+setup() {
+  setup_test_repo
+}
+
+teardown() {
+  teardown_test_repo
+}
+
+# helper: number of git tags in the current repo
+tag_count() { git tag | grep -c . || true; }
+
+##############################################################################
+# The core invariant: no tag is created/pushed while a prep is active
+##############################################################################
+
+@test "prep: active prep suppresses tags for 'ap' and 'new'" {
+  create_version_file "1.4.3"
+
+  run_setver prep major
+  [ "$status" -eq 0 ]
+
+  local before
+  before=$(tag_count)
+
+  # 'ap' bumps the version files but must NOT create a tag
+  echo "work" >> README.md
+  run_setver -f ap
+  [ "$status" -eq 0 ]
+  [ "$(cat VERSION.md)" = "2.0.1" ]
+
+  # 'new patch' must NOT create a tag either
+  run_setver new patch
+  [ "$status" -eq 0 ]
+  [ "$(cat VERSION.md)" = "2.0.2" ]
+
+  # highest-value assertion: the tag count never moved
+  [ "$(tag_count)" -eq "$before" ]
+}
+
+##############################################################################
+# prep major / minor
+##############################################################################
+
+@test "prep major from 1.4.3 creates prep-v2, target 2.0.0, sets files, no tag" {
+  create_version_file "1.4.3"
+
+  run_setver prep major
+  [ "$status" -eq 0 ]
+
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "prep-v2" ]
+  [ -f .setver-prep ]
+  grep -q "SETVER_PREP_TARGET=2.0.0" .setver-prep
+  grep -q "SETVER_PREP_LEVEL=major" .setver-prep
+  [ "$(cat VERSION.md)" = "2.0.0" ]
+  [ "$(tag_count)" -eq 0 ]
+}
+
+@test "prep minor from 1.4.3 creates prep-v1.5 with target 1.5.0" {
+  create_version_file "1.4.3"
+
+  run_setver prep minor
+  [ "$status" -eq 0 ]
+
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "prep-v1.5" ]
+  grep -q "SETVER_PREP_TARGET=1.5.0" .setver-prep
+  [ "$(cat VERSION.md)" = "1.5.0" ]
+  [ "$(tag_count)" -eq 0 ]
+}
+
+@test "prep patch is rejected with a hint to use ap" {
+  create_version_file "1.4.3"
+  run_setver prep patch
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not supported"* ]]
+}
+
+##############################################################################
+# prep finish
+##############################################################################
+
+@test "prep finish releases exactly v2.0.0 on base history" {
+  create_version_file "1.4.3"
+  local base
+  base=$(git rev-parse --abbrev-ref HEAD)
+
+  run_setver prep major
+  echo "drift" >> README.md
+  run_setver -f ap            # version files drift to 2.0.1
+
+  git checkout -q "$base"
+  git merge -q --no-ff -m "merge prep" prep-v2
+
+  run_setver prep finish
+  [ "$status" -eq 0 ]
+
+  [ ! -f .setver-prep ]                       # marker consumed
+  [ "$(cat VERSION.md)" = "2.0.0" ]           # clean target, not the drift
+  run git tag
+  [[ "$output" == *"v2.0.0"* ]]
+  [ "$(git tag | grep -c '^v2')" -eq 1 ]      # exactly one 2.x tag
+}
+
+@test "prep finish --keep-version releases the drifted version" {
+  create_version_file "1.4.3"
+  local base
+  base=$(git rev-parse --abbrev-ref HEAD)
+
+  run_setver prep major
+  echo "a" >> README.md ; run_setver -f ap    # 2.0.1
+  echo "b" >> README.md ; run_setver -f ap    # 2.0.2
+
+  git checkout -q "$base"
+  git merge -q --no-ff -m "merge prep" prep-v2
+
+  run_setver prep finish --keep-version
+  [ "$status" -eq 0 ]
+
+  run git tag
+  [[ "$output" == *"v2.0.2"* ]]
+  [[ "$output" != *"v2.0.0"* ]]
+  [ "$(cat VERSION.md)" = "2.0.2" ]
+}
+
+@test "prep finish refuses when prep branch is not merged into base" {
+  create_version_file "1.4.3"
+  local base
+  base=$(git rev-parse --abbrev-ref HEAD)
+
+  run_setver prep major
+
+  # bring ONLY the marker to base (not a real merge of the prep commits)
+  git checkout -q "$base"
+  git checkout -q prep-v2 -- .setver-prep
+  git add .setver-prep
+  git commit -qm "marker only, not merged"
+
+  run_setver prep finish
+  [ "$status" -ne 0 ]
+  [ "$(git tag | grep -c '^v2')" -eq 0 ]      # no release tag created
+}
+
+##############################################################################
+# prep pause / resume
+##############################################################################
+
+@test "prep pause --stash then resume round-trips uncommitted work" {
+  create_version_file "1.4.3"
+  local base
+  base=$(git rev-parse --abbrev-ref HEAD)
+
+  run_setver prep major
+  echo "uncommitted work" >> README.md
+
+  run_setver prep pause --stash
+  [ "$status" -eq 0 ]
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "$base" ]
+  [ -f .git/setver-prep-session ]
+  [ -z "$(git status -s)" ]                   # stash left a clean tree
+
+  run_setver prep resume
+  [ "$status" -eq 0 ]
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "prep-v2" ]
+  grep -q "uncommitted work" README.md        # stash popped back
+  [ ! -f .git/setver-prep-session ]
+}
+
+@test "prep pause refuses a dirty tree without --stash" {
+  create_version_file "1.4.3"
+  run_setver prep major
+  echo "dirty" >> README.md
+
+  run_setver prep pause
+  [ "$status" -ne 0 ]
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "prep-v2" ]
+}
+
+##############################################################################
+# prep status
+##############################################################################
+
+@test "prep status reports target + suppression on a prep branch, else nothing" {
+  create_version_file "1.4.3"
+
+  run_setver prep status
+  [[ "$output" == *"no prep in progress"* ]]
+
+  run_setver prep major
+  run_setver prep status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"preparing v2.0.0"* ]]
+  [[ "$output" == *"suppressed"* ]]
+}
+
+##############################################################################
+# Cross-cutting: hotfix during a prep
+##############################################################################
+
+@test "hotfix on a branch off the release tag still tags while a prep is active" {
+  create_version_file "1.4.3"
+  create_git_tag "1.4.3"
+
+  run_setver prep major                       # prep active on prep-v2
+
+  # hotfix branches off the v1.4.3 tag -> carries no .setver-prep marker
+  git checkout -q -b hotfix-1.4.4 v1.4.3
+  [ ! -f .setver-prep ]
+  echo "fix" >> README.md
+
+  run_setver -f ap
+  [ "$status" -eq 0 ]
+  run git tag
+  [[ "$output" == *"v1.4.4"* ]]               # hotfix is NOT suppressed
+}
+
+##############################################################################
+# prep abort
+##############################################################################
+
+@test "prep abort deletes the prep branch and returns to base" {
+  create_version_file "1.4.3"
+  local base
+  base=$(git rev-parse --abbrev-ref HEAD)
+
+  run_setver prep major
+  run_setver -f prep abort
+  [ "$status" -eq 0 ]
+
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "$base" ]
+  run git show-ref --verify --quiet refs/heads/prep-v2
+  [ "$status" -ne 0 ]                         # branch is gone
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -103,7 +103,7 @@ if [[ $VERBOSE -eq 1 ]]; then
   BATS_CMD="$BATS_CMD --trace"
 fi
 
-BATS_CMD="$BATS_CMD \"$SCRIPT_DIR/setver.bats\""
+BATS_CMD="$BATS_CMD \"$SCRIPT_DIR/setver.bats\" \"$SCRIPT_DIR/prep.bats\""
 
 # Run tests
 echo "🚀 Running tests..."


### PR DESCRIPTION
## Summary

Two related pieces of work around how setver publishes releases:

### 1. Single `git push` for the combined commands (1 CI run)
`ap`/`autopatch`, `autominor` and `automajor` previously pushed up to three times (auto-commit push, version-bump commit push, tag push), triggering multiple CI runs. They now defer all intermediate pushes and do a **single** `git push -u origin <branch> --tags` at the end, sending commits and tags together — so only **1 CI process** is triggered. Also adds the `automajor` command (kept command names full: `autominor`/`automajor`, no `am`/`aM` aliases).

### 2. `setver prep` — prepared major/minor releases with suppressed tags
Composer/Packagist and most consumers resolve installable versions from **git tags**, which are repository-global. Bumping while developing a `v2` would push intermediate tags (`v2.0.1`, `v2.0.2`, …) that become installable immediately. `prep` turns "one tag, on the base branch, after merge" into an enforced mode.

**Core invariant:** while the committed marker `.setver-prep` exists at the repo root, setver **never creates or pushes a git tag**. Enforced at a single choke point (`prep_block_tag` in `commit_and_tag_version`) plus defensive guards in `push_if_possible "Y"` and `push_all_once`, so no path (`new`/`set`/`ap`/`autominor`/`automajor`) can bypass it. The marker travels into the base branch on merge, keeping tags suppressed until `prep finish` consumes it.

**Commands:**
- `prep major|minor` — start a prep on a `prep-v<target>` branch, set version files to the clean target, commit the marker
- `prep finish` — release the single real tag (clean target by default; `--keep-version` keeps the drifted number; `--no-ff` merges the prep branch locally first). Refuses unless the prep branch is merged into base (`-f` overrides). Pushes commits + tag in one push.
- `prep pause [--stash]` / `prep resume` — step off/back onto the prep branch via a local, untracked session file (`.git/setver-prep-session`); `--stash` round-trips uncommitted work
- `prep status` — target, suppression state, commits since base, and how far base has moved (hotfix nudge)
- `prep abort` — cancel a prep and delete its branch
- `prep patch` is rejected with a hint to use `ap`

**Hotfixes are unaffected:** a branch off the release tag carries no marker, so `setver ap` there tags normally while the prep stays suppressed elsewhere.

## State files
- `.setver-prep` — committed, shared, sourceable `KEY=value`; presence = tag-suppression switch
- `.git/setver-prep-session` — local, never tracked; records the branch/stash for pause↔resume

## Tests & CI
- New `tests/prep.bats` — **12 tests**: the suppression invariant, `prep major`/`minor`, `finish` (default / `--keep-version` / not-merged-refusal), `pause`+`resume`+`--stash`, dirty-pause refusal, `status`, hotfix scenario, `abort`
- Full suite **56/56 passing** (44 existing + 12 new)
- Wired `prep.bats` into `bash_ci.yml`, `tests.yml`, and `run-tests.sh`
- **Shellcheck clean** (exit 0 on all `*.sh`); also silenced one pre-existing SC2001 so Shellcheck CI is green

## Docs
README (`docs/index.md`) gains "Prepared releases" and single-push sections; `CLAUDE.md`, `CHANGELOG.md`, and `--help` updated.

## Notes
- Global `-f` follows the repo's existing convention of preceding the action (like `setver -O push`), e.g. `setver -f prep finish`. The `prep`-specific modifiers (`--keep-version`, `--no-ff`, `--stash`) are accepted after the sub-action as the spec describes.
- One bug caught in testing: the script sets `IFS=$'\n\t'`, so a `read` of a space-separated pair wasn't splitting — fixed with a scoped `IFS=' '`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WgMDL5gqJ4dUYB8mQwpJn

---
_Generated by [Claude Code](https://claude.ai/code/session_012WgMDL5gqJ4dUYB8mQwpJn)_